### PR TITLE
Change PlatformTarget to x86

### DIFF
--- a/Azavea.Open.DAO.Odp.csproj
+++ b/Azavea.Open.DAO.Odp.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="GeoAPI, Version=1.6.4447.25411, Culture=neutral, PublicKeyToken=a1a0da7def465678, processorArchitecture=MSIL">


### PR DESCRIPTION
Visual Studio 2012 was complaining about a processor architecture
mismatch between this project and the Oracle.DataAccess.dll file.
Since the DLL is 32-bit I changed PlatformTarget from "Any CPU" to
x86 to fix this problem.
