### PR TITLE
Fix parameterization of ST_Geometry column values.

### DIFF
--- a/OdpDescriptor.cs
+++ b/OdpDescriptor.cs
@@ -145,11 +145,10 @@ namespace Azavea.Open.DAO.Odp
                 string paramName = DbCaches.ParamNames.Get(x);
                 
                 OracleParameter oracleParam;
-                if (addMe != DBNull.Value && addMe is string && ((string)addMe).Length > 3999)
+                if (addMe != DBNull.Value && addMe.GetType().GetProperty("GeometryType") != null)
                 {
-                    // TODO: ensure the param is passed as a geom and convert to WKT here
-                    // Checking string length to trigger CLOB creation is a hack.
-                    oracleParam = new OracleParameter(paramName, OracleDbType.Clob, ((string)addMe).Length, addMe, ParameterDirection.Input);
+                    oracleParam = new OracleParameter(paramName, OracleDbType.Object, addMe.ToString().Length, addMe.ToString());
+                    oracleParam.UdtTypeName = "SDE.ST_GEOMETRY";
                 }
                 else
                 {


### PR DESCRIPTION
In the context of running the G_REFRESH_PARCEL_ULRS_LAYER ULRS queue
service job, we were unable to insert parcels because the shape field
was not being correctly parameterized. The conditions in the changed
if statement were not met because the shape values are not strings (they
are NTS/GeoAPI geometry objects) and they couldn't be casted to a string.
Even if they were converted to a string using ToString(), the string
lengths were much shorter than 3999 characters (sometimes as small as 300
characters). We know check if a certain property that is specific to geometry
objects is present.

Also, the way the shapes were parameteried was incorrect for ST_Geometry
columns. We need to specify the type as Object, set the UDT type as
ST_Geometry, and pass the string representation of the object.
This is somewhat based off this example for SDO_Geometry columns:
http://stackoverflow.com/questions/11969756.

Refs https://github.com/azavea/oit-ulrs/issues/180
