### PR TITLE
Revert "Fix parameterization of ST_Geometry column values."

### DIFF
--- a/OdpDescriptor.cs
+++ b/OdpDescriptor.cs
@@ -145,10 +145,11 @@ namespace Azavea.Open.DAO.Odp
                 string paramName = DbCaches.ParamNames.Get(x);
                 
                 OracleParameter oracleParam;
-                if (addMe != DBNull.Value && addMe.GetType().GetProperty("GeometryType") != null)
+                if (addMe != DBNull.Value && addMe is string && ((string)addMe).Length > 3999)
                 {
-                    oracleParam = new OracleParameter(paramName, OracleDbType.Object, addMe.ToString().Length, addMe.ToString());
-                    oracleParam.UdtTypeName = "SDE.ST_GEOMETRY";
+                    // TODO: ensure the param is passed as a geom and convert to WKT here
+                    // Checking string length to trigger CLOB creation is a hack.
+                    oracleParam = new OracleParameter(paramName, OracleDbType.Clob, ((string)addMe).Length, addMe, ParameterDirection.Input);
                 }
                 else
                 {

--- a/OdpDescriptor.cs
+++ b/OdpDescriptor.cs
@@ -145,7 +145,7 @@ namespace Azavea.Open.DAO.Odp
                 string paramName = DbCaches.ParamNames.Get(x);
                 
                 OracleParameter oracleParam;
-                if (addMe != DBNull.Value && addMe is string && ((string)addMe).Length > 3999)
+                if (addMe != DBNull.Value && addMe is string && ((string)addMe).Length >= 148)
                 {
                     // TODO: ensure the param is passed as a geom and convert to WKT here
                     // Checking string length to trigger CLOB creation is a hack.


### PR DESCRIPTION
This reverts commit b888d10a7b66c6b10c8c22ea42e0c6f395923d60.

A problem with the ULRS configuration was the cause of INSERT issues,
and not this logic. Unfortunately, addMe is a string, so the logic
that checks for geometries has to stay for now.

Refs https://github.com/azavea/oit-ulrs/issues/180
